### PR TITLE
Fix query getter bug in request

### DIFF
--- a/packages/server/lib/request.ts
+++ b/packages/server/lib/request.ts
@@ -40,9 +40,9 @@ export default {
      * @return {String}
      * @api public
      */
-    get query(): number {
-        const { parseurl, compileQueryParser } = require('../utils');
-        var querystring = parseurl(this).query;
+    get query(): Record<string, any> {
+        const { parseurl } = require('../utils');
+        const querystring = parseurl(this.req).query;
         return qs.parse(querystring);
     },
 


### PR DESCRIPTION
## Summary
- fix bug in request's query getter so it parses url from the underlying request

## Testing
- `pnpm test` *(fails: Error: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.10.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684dba5d4ec083338ca226ea7e44ae4f