### PR TITLE
Add multer upload middleware

### DIFF
--- a/packages/multer/LICENSE
+++ b/packages/multer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Andre Ferreira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/multer/Readme.md
+++ b/packages/multer/Readme.md
@@ -1,0 +1,128 @@
+<p align="center">
+  <a href="https://cmmv.io/" target="blank"><img src="https://raw.githubusercontent.com/cmmvio/docs.cmmv.io/main/public/assets/logo_CMMV2_icon.png" width="300" alt="CMMV Logo" /></a>
+</p>
+<p align="center">Contract-Model-Model-View (CMMV) <br/> Building scalable and modular applications using contracts.</p>
+<p align="center">
+    <a href="https://www.npmjs.com/package/@cmmv/core"><img src="https://img.shields.io/npm/v/@cmmv/core.svg" alt="NPM Version" /></a>
+    <a href="https://github.com/cmmvio/cmmv-server/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/@cmmv/core.svg" alt="Package License" /></a>
+    <a href="https://dl.circleci.com/status-badge/redirect/circleci/QyJWAYrZ9JTfN1eubSDo5u/JEtDUbr1cNkGRxfKFJo7oR/tree/main" target="_blank"><img src="https://dl.circleci.com/status-badge/img/circleci/QyJWAYrZ9JTfN1eubSDo5u/JEtDUbr1cNkGRxfKFJo7oR/tree/main.svg?style=svg" alt="CircleCI" /></a>
+</p>
+
+<p align="center">
+  <a href="https://cmmv.io">Documentation</a> &bull;
+  <a href="https://github.com/cmmvio/cmmv-server/issues">Report Issue</a>
+</p>
+
+## Description
+
+``@cmmv/server`` is inspired by the popular [Express.js](https://expressjs.com/pt-br/) framework but has been entirely rewritten in TypeScript with performance improvements in mind. The project integrates common plugins like ``body-parser``, ``compression``, ``cookie-parser``, ``cors``, ``etag``, ``helmet`` and ``serve-static`` out of the box. Additionally, it plans to support any Express.js-compatible plugin in the near future.
+
+## Installation
+
+Install the ``@cmmv/server`` package via npm:
+
+```bash
+$ pnpm add @cmmv/server
+```
+
+## Quick Start
+
+Below is a simple example of how to create a new CMMV application:
+
+```typescript
+import cmmv, { json, urlencoded, serverStatic } from '@cmmv/server';
+import etag from '@cmmv/etag';
+import cors from '@cmmv/cors';
+import cookieParser from '@cmmv/cookie-parser';
+import compression from '@cmmv/compression';
+import helmet from '@cmmv/helmet';
+
+const app = cmmv();
+const host = '0.0.0.0';
+const port = 3000;
+
+app.use(serverStatic('public'));
+app.use(cors());
+app.use(etag({ algorithm: 'murmurhash' }));
+app.use(cookieParser());
+app.use(json({ limit: '50mb' }));
+app.use(urlencoded({ limit: '50mb', extended: true }));
+app.use(compression({ level: 6 }));
+app.use(
+    helmet({
+        contentSecurityPolicy: {
+            useDefaults: false,
+            directives: {
+                defaultSrc: ["'self'"],
+                scriptSrc: ["'self'", 'example.com'],
+                objectSrc: ["'none'"],
+                upgradeInsecureRequests: [],
+            },
+        },
+    }),
+);
+
+app.set('view engine', 'pug');
+
+app.get('/view', async (req, res) => {
+    res.render('index', { title: 'Hey', message: 'Hello there!' });
+});
+
+app.get('/', async (req, res) => {
+    res.send('Hello World');
+});
+
+app.get('/json', async (req, res) => {    
+    res.json({ hello: 'world' });
+});
+
+app.get('/user/:id', async (req, res) => {
+    res.send('User ' + req.params.id);
+});
+
+app.get('/users', async (req, res) => {
+    res.json(req.query);
+});
+
+app.post('/test', async (req, res) => {
+    console.log(req.body);
+    res.send('ok');
+});
+
+app.listen({ host, port })
+.then(server => {
+    console.log(
+        `Listen on http://${server.address().address}:${server.address().port}`,
+    );
+})
+.catch(err => {
+    throw Error(err.message);
+});
+```
+
+## Features
+
+* **Performance Optimized:** Faster and more efficient with improvements over Express.js.
+* **Built-in Plugins:** Includes commonly used middleware like ``compression``, ``body-parser``, ``cookie-parser``, and more.
+* **TypeScript First:** Fully written in TypeScript for better type safety and developer experience.
+* **Express.js Compatibility:** Plans to support Express.js-compatible plugins.
+* **HTTP/2 Support:** Native support for HTTP/2, improving speed and connection performance.
+
+## Benchmarks
+
+* [https://github.com/fastify/benchmarks](https://github.com/fastify/benchmarks)
+* Machine: linux x64 | 32 vCPUs | 128.0GB Mem
+* Node: v20.17.0
+* Run: Sun Mar 16 2025 14:51:12 GMT+0000 (Coordinated Universal Time)
+* Method: ``autocannon -c 100 -d 40 -p 10 localhost:3000``
+
+|                          | Version  | Router | Requests/s | Latency (ms) | Throughput/Mb |
+|--------------------------|----------|--------|------------|--------------|---------------|
+| bare                     | v20.17.0 | ✗      | 51166.4    | 19.19        | 9.13          |
+| cmmv                     | 0.9.4    | ✓      | 46879.2    | 21.03        | 8.40          |
+| fastify                  | 5.2.1    | ✓      | 46488.0    | 21.19        | 8.33          |
+| h3                       | 1.15.1   | ✗      | 34626.2    | 28.37        | 6.18          |
+| restify                  | 11.1.0   | ✓      | 34020.6    | 28.88        | 6.07          |
+| koa                      | 2.16.0   | ✗      | 31031.0    | 31.72        | 5.53          |
+| express                  | 5.0.1    | ✓      | 12913.6    | 76.87        | 2.30          |
+

--- a/packages/multer/index.ts
+++ b/packages/multer/index.ts
@@ -1,0 +1,68 @@
+/*!
+ * CMMV Multer (File Upload)
+ * Copyright(c) 2024 Andre Ferreira
+ * MIT Licensed
+ */
+
+/*!
+ * formidable
+ * Copyright(c) 2011 Felix Geisendoerfer
+ * MIT Licensed
+ *
+ * @see https://github.com/node-formidable/formidable
+ */
+
+import { IncomingForm, File } from 'formidable';
+
+export interface MulterFile extends File {}
+
+export interface MulterOptions {
+    dest?: string;
+}
+
+export class MulterMiddleware {
+    public middlewareName: string = 'multer';
+
+    private options: MulterOptions;
+
+    constructor(options?: MulterOptions) {
+        this.options = options || {};
+    }
+
+    async process(req, res, next?) {
+        if (req.app && typeof req.app.addContentTypeParser == 'function') {
+            req.app.addContentTypeParser(
+                'multipart/form-data',
+                this.cmmvMiddleware.bind(this),
+            );
+        } else this.expressMiddleware.call(this, req, res, next);
+    }
+
+    expressMiddleware(req, res, done) {
+        this.cmmvMiddleware(req, res, null, done);
+    }
+
+    cmmvMiddleware(req, res, payload, done) {
+        const form = new IncomingForm({ uploadDir: this.options.dest });
+
+        form.parse(req, (err, fields, files) => {
+            if (err) {
+                done && done(err);
+                return;
+            }
+            req.body = Object.assign({}, req.body, fields);
+            req.files = files;
+            done && done();
+        });
+    }
+}
+
+export default async function (options?: MulterOptions) {
+    const middleware = new MulterMiddleware(options);
+    return (req, res, next) => middleware.process(req, res, next);
+}
+
+export const multer = function (options?: MulterOptions) {
+    const middleware = new MulterMiddleware(options);
+    return (req, res, next) => middleware.process(req, res, next);
+};

--- a/packages/multer/package.json
+++ b/packages/multer/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@cmmv/multer",
+  "version": "0.12.0",
+  "description": "Simple file upload middleware for CMMV using formidable",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cmmvio/cmmv-server.git"
+  },
+  "author": "Andre Ferreira",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/cmmvio/cmmv-server/issues"
+  },
+  "homepage": "https://cmmv.io",
+  "keywords": [
+    "cmmv",
+    "multer",
+    "upload",
+    "middleware"
+  ],
+  "dependencies": {
+    "formidable": "^3.5.2",
+    "@cmmv/server": "^0.12.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.6.1"
+  }
+}

--- a/packages/multer/test/multer.spec.ts
+++ b/packages/multer/test/multer.spec.ts
@@ -1,0 +1,33 @@
+/* eslint-disable */
+
+import { strict as assert } from 'assert';
+import * as request from 'supertest';
+import cmmv from '@cmmv/server';
+
+import multer from '..';
+
+function createServer(opts?: any) {
+    const app = cmmv();
+    app.use(multer(opts));
+    app.post('/', (req, res) => {
+        res.status(200).json({ body: req.body, files: req.files });
+    });
+    return app;
+}
+
+describe('multer', function () {
+    it('parses multipart form and exposes files', function (done) {
+        const server = createServer();
+        request(server)
+            .post('/')
+            .field('name', 'test')
+            .attach('file', Buffer.from('hello'), 'hello.txt')
+            .expect(200)
+            .expect(res => {
+                const data = JSON.parse(res.text);
+                assert.equal(data.body.name, 'test');
+                assert.ok(data.files.file);
+            })
+            .end(done);
+    });
+});

--- a/packages/multer/tsconfig.build.json
+++ b/packages/multer/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": ".",
+        "rootDir": "."
+    },
+    "exclude": ["node_modules", "dist"]
+}

--- a/packages/multer/tsconfig.json
+++ b/packages/multer/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../tsconfig.build.json",
+    "compilerOptions": {
+        "types": ["node"]
+    },
+    "files": [],
+    "include": [],
+    "references": [{ "path": "./tsconfig.build.json" }]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -10,5 +10,6 @@
         { "path": "./server/tsconfig.build.json" },
         { "path": "./server-static/tsconfig.build.json" },
         { "path": "./proxy/tsconfig.build.json" }
+        ,{ "path": "./multer/tsconfig.build.json" }
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,7 +48,9 @@
             "@cmmv/server-static": ["packages/server-static"],
             "@cmmv/server-static/*": ["packages/server-static/*"],
             "@cmmv/proxy": ["packages/proxy"],
-            "@cmmv/proxy/*": ["packages/proxy/*"]
+            "@cmmv/proxy/*": ["packages/proxy/*"],
+            "@cmmv/multer": ["packages/multer"],
+            "@cmmv/multer/*": ["packages/multer/*"]
         }
     },
     "include": ["packages/**/*", "src/**/*.ts"],


### PR DESCRIPTION
## Summary
- implement file upload middleware package `@cmmv/multer`
- expose new package path mappings
- update packages tsconfig references
- add basic test for upload
- update test to use CMMV server

## Testing
- `npm test` *(fails: Cannot find module formidable / @cmmv/server)*

------
https://chatgpt.com/codex/tasks/task_e_684dbb925ba48333829d952ff994c6e2