### PR TITLE
Add SSE test for response.write

### DIFF
--- a/packages/server/lib/response.ts
+++ b/packages/server/lib/response.ts
@@ -1828,7 +1828,9 @@ export default {
     uncork() {
         this.res.uncork();
     },
-
+    write(chunk: any, encoding?: BufferEncoding, cb?: Function) {
+        return this.res.write(chunk, encoding, cb);
+    },
     writeEarlyHints(hints, callback) {
         this.res.writeEarlyHints(hints, callback);
         return this;

--- a/packages/server/test/response.write.spec.ts
+++ b/packages/server/test/response.write.spec.ts
@@ -1,0 +1,30 @@
+import { strict as assert } from 'assert';
+import * as http from 'node:http';
+import { AddressInfo } from 'net';
+import cmmv from '..';
+
+describe('response.write', function() {
+  it('should stream data using Server-Sent Events', function(done) {
+    const app = cmmv();
+
+    app.get('/stream', (req, res) => {
+      res.set('Content-Type', 'text/event-stream');
+      res.flushHeaders();
+      res.write('data: first\n\n');
+      res.write('data: second\n\n');
+      res.res.end();
+    });
+
+    app.listen({ port: 0 }).then(server => {
+      const port = (server.address() as AddressInfo).port;
+      http.get({ host: '127.0.0.1', port, path: '/stream' }, res2 => {
+        let body = '';
+        res2.on('data', chunk => { body += chunk.toString(); });
+        res2.on('end', () => {
+          assert.strictEqual(body, 'data: first\n\ndata: second\n\n');
+          server.close(done);
+        });
+      }).on('error', done);
+    }).catch(done);
+  });
+});


### PR DESCRIPTION
## Summary
- expose underlying `ServerResponse.write` in the response wrapper
- add mocha test ensuring `response.write` works for Server‑Sent Events

## Testing
- `pnpm test` *(fails: Timeout of 2000ms exceeded in cors tests)*

------
https://chatgpt.com/codex/tasks/task_e_684dbb0a321883339a56f7f086b309de