### PR TITLE
Add express-like hooks to proxy

### DIFF
--- a/packages/proxy/Readme.md
+++ b/packages/proxy/Readme.md
@@ -126,3 +126,35 @@ app.listen({ host, port })
 | koa                      | 2.16.0   | ✗      | 31031.0    | 31.72        | 5.53          |
 | express                  | 5.0.1    | ✓      | 12913.6    | 76.87        | 2.30          |
 
+## Proxy Options
+
+The proxy middleware now supports several hooks inspired by
+[express-http-proxy](https://github.com/villadora/express-http-proxy). These
+allow customization of both the outbound request and the returned response.
+
+- `filter(req, res)`: Skip proxying when the function returns `false`.
+- `proxyReqPathResolver(req)`: Resolve the path to use for the proxied request.
+- `proxyReqOptDecorator(opts, req)`: Modify the request options before sending.
+- `userResDecorator(proxyRes, data, req, res)`: Transform the response body.
+- `proxyErrorHandler(err, req, res, next)`: Custom error handler for proxy
+  failures.
+
+Example usage:
+
+```typescript
+import proxy from '@cmmv/proxy';
+
+app.use(
+    proxy({
+        target: 'https://example.com',
+        filter: (req) => req.method === 'GET',
+        proxyReqPathResolver: req => `/api${req.url}`,
+        userResDecorator: (proxyRes, data) => {
+            const body = JSON.parse(data.toString());
+            body.extra = true;
+            return JSON.stringify(body);
+        },
+    }),
+);
+```
+

--- a/packages/proxy/index.ts
+++ b/packages/proxy/index.ts
@@ -15,6 +15,19 @@ export interface ProxyOptions {
     timeout?: number;
     headers?: { [key: string]: string };
     secure?: boolean;
+    filter?: (req: any, res: any) => boolean | Promise<boolean>;
+    proxyReqPathResolver?: (req: any) => string | Promise<string>;
+    proxyReqOptDecorator?: (
+        options: http.RequestOptions,
+        req: any,
+    ) => http.RequestOptions | Promise<http.RequestOptions>;
+    userResDecorator?: (
+        proxyRes: http.IncomingMessage,
+        proxyResData: Buffer,
+        req: any,
+        res: any,
+    ) => any | Promise<any>;
+    proxyErrorHandler?: (err: any, req: any, res: any, next?: any) => void;
 }
 
 export class ProxyMiddleware {
@@ -36,9 +49,23 @@ export class ProxyMiddleware {
 
     async process(req, res, next?) {
         try {
+            if (this.options.filter) {
+                const shouldProxy = await Promise.resolve(
+                    this.options.filter(req, res),
+                );
+                if (!shouldProxy) {
+                    if (next) return next();
+                    return;
+                }
+            }
+
             await this.handleProxy(req, res);
             if (next) next();
         } catch (error) {
+            if (this.options.proxyErrorHandler) {
+                return this.options.proxyErrorHandler(error, req, res, next);
+            }
+
             console.error('Proxy error:', error);
             if (!res.headersSent) {
                 res.statusCode = 500;
@@ -49,20 +76,30 @@ export class ProxyMiddleware {
     }
 
     private async handleProxy(req, res): Promise<void> {
-        return new Promise((resolve, reject) => {
+        return new Promise(async (resolve, reject) => {
             let targetPath = req.url;
-            if (this.options.pathRewrite) {
-                for (const [pattern, replacement] of Object.entries(
-                    this.options.pathRewrite,
-                )) {
-                    const regex = new RegExp(pattern);
-                    targetPath = targetPath.replace(regex, replacement);
+
+            try {
+                if (this.options.proxyReqPathResolver) {
+                    const resolved = await Promise.resolve(
+                        this.options.proxyReqPathResolver(req),
+                    );
+                    if (resolved) targetPath = resolved;
+                } else if (this.options.pathRewrite) {
+                    for (const [pattern, replacement] of Object.entries(
+                        this.options.pathRewrite,
+                    )) {
+                        const regex = new RegExp(pattern);
+                        targetPath = targetPath.replace(regex, replacement);
+                    }
                 }
+            } catch (e) {
+                return reject(e);
             }
 
             const originalReq = req.req || req;
 
-            const requestOptions = {
+            let requestOptions: http.RequestOptions = {
                 hostname: this.targetUrl.hostname,
                 port:
                     this.targetUrl.port ||
@@ -77,13 +114,32 @@ export class ProxyMiddleware {
                 Object.assign(requestOptions.headers, this.options.headers);
 
             if (this.options.changeOrigin)
-                requestOptions.headers.host = this.targetUrl.host;
+                requestOptions.headers['host'] = this.targetUrl.host;
+
+            try {
+                if (this.options.proxyReqOptDecorator) {
+                    const decorated = await Promise.resolve(
+                        this.options.proxyReqOptDecorator(
+                            requestOptions,
+                            originalReq,
+                        ),
+                    );
+                    if (decorated) requestOptions = decorated;
+                }
+            } catch (e) {
+                return reject(e);
+            }
 
             const httpModule =
                 this.targetUrl.protocol === 'https:' ? https : http;
 
+            if (this.targetUrl.protocol === 'https:') {
+                (requestOptions as https.RequestOptions).rejectUnauthorized =
+                    this.options.secure;
+            }
+
             const proxyReq = httpModule.request(requestOptions, proxyRes => {
-                res.statusCode = proxyRes.statusCode;
+                res.statusCode = proxyRes.statusCode || 500;
 
                 Object.keys(proxyRes.headers).forEach(key => {
                     res.setHeader(key, proxyRes.headers[key]);
@@ -95,9 +151,40 @@ export class ProxyMiddleware {
                     responseData = Buffer.concat([responseData, chunk]);
                 });
 
-                proxyRes.on('end', () => {
+                proxyRes.on('end', async () => {
                     try {
-                        res.end(responseData);
+                        let dataToSend: any = responseData;
+
+                        if (this.options.userResDecorator) {
+                            const decorated = await Promise.resolve(
+                                this.options.userResDecorator(
+                                    proxyRes,
+                                    responseData,
+                                    req,
+                                    res,
+                                ),
+                            );
+                            if (decorated !== undefined) {
+                                if (
+                                    Buffer.isBuffer(decorated) ||
+                                    typeof decorated === 'string'
+                                ) {
+                                    dataToSend = decorated;
+                                } else {
+                                    dataToSend = Buffer.from(
+                                        JSON.stringify(decorated),
+                                    );
+                                    if (!res.getHeader('content-type')) {
+                                        res.setHeader(
+                                            'content-type',
+                                            'application/json',
+                                        );
+                                    }
+                                }
+                            }
+                        }
+
+                        res.end(dataToSend);
                         resolve();
                     } catch (error) {
                         reject(error);
@@ -130,7 +217,8 @@ export class ProxyMiddleware {
                 } else if (typeof req.body === 'object') {
                     bodyData = JSON.stringify(req.body);
                     if (!requestOptions.headers['content-type']) {
-                        requestOptions.headers['content-type'] = 'application/json';
+                        requestOptions.headers['content-type'] =
+                            'application/json';
                     }
                 } else {
                     bodyData = String(req.body);


### PR DESCRIPTION
## Summary
- extend `proxy` middleware with express-http-proxy-style hooks
- document the new proxy options
- fix SSL protocol selection for HTTP vs HTTPS targets

## Testing
- `pnpm run lint` *(fails: 51 errors)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684dea0593e8833380519e125cebfbbf